### PR TITLE
running sheduler time from RTC0

### DIFF
--- a/include/rtc.h
+++ b/include/rtc.h
@@ -21,6 +21,10 @@ bool eventTickRtc(RtcModule rtcModule);
 bool eventOvrflwRtc(RtcModule rtcModule);
 bool eventCompare(RtcModule rtcModule, CompareReg compareReg);
 
+void clearEventTickRtc(RtcModule rtcModule);
+void clearEventOvrflwRtc(RtcModule rtcModule);
+void clearEventCompareRtc(RtcModule rtcModule, CompareReg compareReg);
+
 void enableInterruptRtc(RtcModule rtcModule, RtcInterrupt rtcInterrupt);
 void disableInterruptRtc(RtcModule rtcModule, RtcInterrupt rtcInterrupt);
 

--- a/include/rtc.h
+++ b/include/rtc.h
@@ -1,6 +1,8 @@
 #ifndef RTC_H
 #define RTC_H
 
+#include <stdbool.h>
+
 #define MAX_PRESCALER_RTC 4095u
 #define MAX_COMPARE_VAL 16777215u
 

--- a/source/main.c
+++ b/source/main.c
@@ -4,6 +4,8 @@
 #include <led.h>
 #include <sheduler.h>
 #include <clock.h>
+#include <rtc.h>
+#include <nvic.h>
 
 #define LED_1_BLINK_PERIOD  500
 #define LED_2_BLINK_PERIOD  501
@@ -18,6 +20,17 @@ int main(void) {
     setHfxoDebounce(HFXO_DEBOUNCE_1024US);
     startHfxoClock();
     initSysTime(RELOAD_1MS_64MHZ);
+
+    setLfClkSource(LFCLK_XTAL);
+    startLfxoClock();
+
+    setPrescalerRtc(RTC_0, 32);
+    startCounterRtc(RTC_0);
+    enableInterruptRtc(RTC_0, INT_TICK);
+
+    NVIC_enableIrq(RTC0);
+    NVIC_enableGlobalIrq();
+
     initLed(LED_1);
     initLed(LED_2);
     initLed(LED_3);

--- a/source/rtc.c
+++ b/source/rtc.c
@@ -186,6 +186,37 @@ bool eventCompare(RtcModule rtcModule, CompareReg compareReg) {
     return res;
 }
 
+void clearEventTickRtc(RtcModule rtcModule) {
+    if ( isCorrectModuleRtc(rtcModule) == false ) {
+        return;
+    }
+    
+    SET_BIT_LO(rtc[rtcModule]->EVENTS_TICK, EVENTS_TICK_BIT);
+}
+void clearEventOvrflwRtc(RtcModule rtcModule) {
+    if ( isCorrectModuleRtc(rtcModule) == false ) {
+        return;
+    }
+    
+    SET_BIT_LO(rtc[rtcModule]->EVENTS_OVRFLW, EVENTS_OVRFLW_BIT);
+}
+void clearEventCompareRtc(RtcModule rtcModule, CompareReg compareReg) {
+    if ( isCorrectModuleRtc(rtcModule) == false) {
+        return;
+    }
+
+    if ( isCorrectCompareReg(compareReg) == false ) {
+        return;
+    }
+    
+    // according to datasheet CC[3] not implemented in RTC[0]
+    if (rtcModule == RTC_0 && compareReg == CC_3) {
+        return;
+    }
+    
+    SET_BIT_LO(rtc[rtcModule]->CC[compareReg], EVENTS_COMPARE_BIT);
+}
+
 void enableInterruptRtc(RtcModule rtcModule, RtcInterrupt rtcInterrupt) {
     if ( isCorrectModuleRtc(rtcModule) == false ) {
         return;
@@ -283,6 +314,6 @@ uint32_t getCompareRegRtc(RtcModule rtcModule, CompareReg compareReg) {
 }
 
 void Rtc0Handler(void) {
-    rtc[0]->EVENTS_TICK = 0;
+    clearEventTickRtc(RTC_0);
     tickShedulerTime();
 }

--- a/source/rtc.c
+++ b/source/rtc.c
@@ -1,6 +1,8 @@
 #include <stdint.h>
 #include <stdbool.h>
 #include <rtc.h>
+#include <sheduler.h>
+#include <nvic.h>
 
 #define RTC_0_BASE_ADDRESS 0x4000B000u
 #define RTC_1_BASE_ADDRESS 0x40011000u
@@ -278,4 +280,9 @@ uint32_t getCompareRegRtc(RtcModule rtcModule, CompareReg compareReg) {
     }
 
     return rtc[rtcModule]->CC[compareReg];
+}
+
+void Rtc0Handler(void) {
+    rtc[0]->EVENTS_TICK = 0;
+    tickShedulerTime();
 }

--- a/source/systime.c
+++ b/source/systime.c
@@ -37,7 +37,6 @@ static void enableSysTickInt(void) {
 __attribute__((interrupt("FIQ"))) void SysTimeHandler(void) {
     disableSysTickInt();
     systime++;
-    tickShedulerTime();
     enableSysTickInt();
 }
 


### PR DESCRIPTION
Moving sheduler time keeping from SysTick to RTC0. This is because at SoC sleep time SysTick is stopped, but RTC keeps running if enabled.